### PR TITLE
Define config by start date - not period

### DIFF
--- a/cb_config.json
+++ b/cb_config.json
@@ -1,0 +1,24 @@
+{
+  "211108":{
+    "n_view":"3",
+    "view_name":["Z","Y","U"],
+    "view_type":["Coll.","Ind.","Ind."],
+    "view_angle":["0", "90", "138"],
+    "view_pitch":["0.5125", "0.517", "0.8695"],
+    "n_chan_per_view":["576", "640", "384"],
+    "top":{
+	"sub_path":"np02/rawdata_cb",
+	"n_tot_channels":"1920",
+	"sampling":"2.5",
+	"n_sample":"10000",
+	"ADC_to_fC":"1"
+    },
+    "bot":{
+	"sub_path":"np04/vd-coldbox-bottom/raw/2021/detector/test/None",
+	"n_tot_channels":"1792",
+	"sampling":"2",
+	"n_sample":"8192",
+	"ADC_to_fC":"1"
+    }
+  } 
+}


### PR DESCRIPTION
I suggest we have a top field which corresponds to the starting date of the configuration. Then 
1. we know when the config is valid. The code can easily check which config to look into, given the data file it analyses.
2. we can easily append subsequent configurations