### PR TITLE
Working at FNAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ You need miniconda installed :
 
 https://docs.conda.io/en/latest/miniconda.html#linux-installers
 
+:warning: at FNAL, anaconda is not allowed anymore, use miniforge instead:
+
+`wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh`
+
 and then get the librairies as stated in **lardenv.yml** :
 
 `conda env create -f lardenv.yml`
@@ -37,14 +41,16 @@ To launch lardon, type `python lardon.py` with the following arguments:<br/>
 **These options may be also needed to retrieve the raw file**:<br/>
 * `-flow <flow nb> -writer <writer nb>` if used <br/>
 * `-hash <ab/cd>` the hashed sub-directory where the data is (use rucio to find out) <br/>
-* `-serv <server nb> the server nb where the data was taken <br/>
+* `-serv <server nb>` the server nb where the data was taken (may be needed for some PDVD runs, you can get it in the file name under the `-s0x-` part)<br/>
 
 **Alternatively, you can provide the whole path of the file:**<br/>
 Should be used for using files outside of cern/fermilab<br/>
 In such case you need to first get the justin/rucio authentication sorted<br/>
-and do `export LD_PRELOAD=/your/conda/env/lib/libXrdPosixPreload.so` before running lardon. The option to use is:<br/>
+and do `export LD_PRELOAD=/your/conda/env/lib/libXrdPosixPreload.so` before running lardon.<br/>
+The option to use is:<br/>
 * `-file root://the.full.file.path.you.got.from.rucio.the_file.h5`
-:exclamation: you still need to provide run and subfile numbers<br/>
+
+:exclamation: you still need to provide run and subfile numbers ! <br/>
 
 **Depending on the requested reconstruction**:<br/>
 * `-trk` if you want the **charge/TPC** reconstruction<br/>
@@ -79,9 +85,9 @@ the output h5file will be **$store_path/pdvd_39246_00_full_example.h5**
 NB: When `flow_nb` and `writer_nb` are both 0, you don't need to provide it.
 The output h5file will be **$store_path/cbbot_37040_23_few_events.h5**
 
-*e.g. 4* : To run TPC & PDS reco on events 5 and 6 VD-CD file located at root://somewhere.abc:1094directory/raw/data/np02vdcoldbox_raw_run037041_0079_df-s02-d0_dw_0_20250705T130324.hdf5
+*e.g. 4* : To run TPC & PDS reco on events 5 and 6 VD-CD file located at root://somewhere.abc:1094/directory/raw/data/np02vdcoldbox_raw_run037041_0079_df-s02-d0_dw_0_20250705T130324.hdf5
 
-`python lardon.py -det cbbot -run 37041 -sub 79 -file root://somewhere.abc:1094directory/raw/data/np02vdcoldbox_raw_run037041_0079_df-s02-d0_dw_0_20250705T130324.hdf5 -n 6 -skip 4 -trk -pds -out evt_5_6_both_reco`
+`python lardon.py -det cbbot -run 37041 -sub 79 -file root://somewhere.abc:1094/directory/raw/data/np02vdcoldbox_raw_run037041_0079_df-s02-d0_dw_0_20250705T130324.hdf5 -n 6 -skip 4 -trk -pds -out evt_5_6_both_reco`
 
 the output h5file will be **$store_path/cbbot_37041_79_evt_5_6_both_reco.h5**
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,21 @@ To launch lardon, type `python lardon.py` with the following arguments:<br/>
 * `-det <cb1top/cb1bot/cbtop/cbbot/dp/50l/pdhd/pdvd>` which detector<br/>
 * `-run <run nb>` which run number
 * `-sub <subfile name>` which subfile (*e.g.* 1_a, 0)<br/>
+**These options may be also needed to retrieve the raw file**:<br/>
 * `-flow <flow nb> -writer <writer nb>` if used <br/>
 * `-hash <ab/cd>` the hashed sub-directory where the data is (use rucio to find out) <br/>
+* `-serv <server nb> the server nb where the data was taken <br/>
+
+**Alternatively, you can provide the whole path of the file:**<br/>
+Should be used for using files outside of cern/fermilab<br/>
+In such case you need to first get the justin/rucio authentication sorted<br/>
+and do `export LD_PRELOAD=/your/conda/env/lib/libXrdPosixPreload.so` before running lardon. The option to use is:<br/>
+* `-file root://the.full.file.path.you.got.from.rucio.the_file.h5`
+:exclamation: you still need to provide run and subfile numbers<br/>
 
 **Depending on the requested reconstruction**:<br/>
 * `-trk` if you want the **charge/TPC** reconstruction<br/>
-* `-pds` if you want the **PDS** reconstruction [DO NOT USE NOW, NEEDS DEBUGGING]<br/>
+* `-pds` if you want the **PDS** reconstruction [DOES NOT WORK FOR PDHD, okish for PDVD]<br/>
 **You can ask both!**
 
 *Optional*:<br/>
@@ -53,7 +62,7 @@ To launch lardon, type `python lardon.py` with the following arguments:<br/>
 
 *e.g. 1* : To run TPC reco on event 11 of PDVD file `np02vd_raw_run039229_0024_df-s05-d4_dw_0_20250829T115242.hdf5` on lxplus: 
 
-`python lardon.py -det pdvd -run 39229 -sub 24 -flow 4 -writer 0 -hash 86/ad -event 11 -out one_event -trk`
+`python lardon.py -det pdvd -run 39229 -sub 24 -flow 4 -writer 0 -serv 5 -hash 86/ad -event 11 -out one_event -trk`
 
 the output h5file will be **$store_path/pdvd_39229_24_40_one_event.h5**
 
@@ -70,6 +79,11 @@ the output h5file will be **$store_path/pdvd_39246_00_full_example.h5**
 NB: When `flow_nb` and `writer_nb` are both 0, you don't need to provide it.
 The output h5file will be **$store_path/cbbot_37040_23_few_events.h5**
 
+*e.g. 4* : To run TPC & PDS reco on events 5 and 6 VD-CD file located at root://somewhere.abc:1094directory/raw/data/np02vdcoldbox_raw_run037041_0079_df-s02-d0_dw_0_20250705T130324.hdf5
+
+`python lardon.py -det cbbot -run 37041 -sub 79 -file root://somewhere.abc:1094directory/raw/data/np02vdcoldbox_raw_run037041_0079_df-s02-d0_dw_0_20250705T130324.hdf5 -n 6 -skip 4 -trk -pds -out evt_5_6_both_reco`
+
+the output h5file will be **$store_path/cbbot_37041_79_evt_5_6_both_reco.h5**
 
 # LARDON Conventions
 * In lardon, electrons drift along the third / `z` axis.

--- a/det_spec.py
+++ b/det_spec.py
@@ -30,10 +30,12 @@ def configure(detector, run, do_pds, hash_path):
         key = fname.get_data_path(locations, run, hash_path)
 
         if(key == "none"):
-            print("sorry but the data does not seem to exists in the paths provided ... bye")
-            exit()        
-        cf.domain = key
-        cf.data_path = locations[key]
+            print("the data does not seem to exists in the paths provided in path.json file")
+            print("if you have not provided the file full path (option -file), lardon will crash")
+            #exit()
+        else:
+            cf.domain = key
+            cf.data_path = locations[key]
 
         
 

--- a/lardenv.yml
+++ b/lardenv.yml
@@ -10,7 +10,7 @@ dependencies:
   - scikit-learn
   - scipy
   - uproot
-  - numexpr=2.8.4
+  - numexpr
   - pytables
   - h5py
   - vitables
@@ -19,6 +19,7 @@ dependencies:
   - fast-histogram
   - pandas
   - psutil
+  - xrootd
   - pip
   - pip:
     - rtree

--- a/lardon.py
+++ b/lardon.py
@@ -26,7 +26,7 @@ parser.add_argument('-out', dest='outname', help='extra name on the output', def
 parser.add_argument('-skip', dest='evt_skip', type=int, help='nb of events to skip', default=0)
 parser.add_argument('-event', dest='single_event', type=int, help='Look at a specific event in the file', default=-1)
 
-parser.add_argument('-f', '--file', help="Custom input filename")
+parser.add_argument('-file', type=str, dest="custom_file_path", help="provide the raw file entire path", default=None)
 
 parser.add_argument('-pulse', dest='is_pulse', action='store_true', help='Used for charge pulsing data')
 
@@ -87,6 +87,8 @@ if(is_pulse == True):
 dataflow = args.dataflow
 datawriter = args.datawriter
 daqserver = args.daqserver
+custom_file_path = args.custom_file_path
+
 
 is_job = args.is_job
 
@@ -124,6 +126,9 @@ else:
         dataflow = "0"
     if(datawriter == "-1"):  
         datawriter = "0"
+
+if(custom_file_path):
+    print('---> Will read file ', custom_file_path)
 
 
 """ output file """
@@ -181,7 +186,7 @@ cmap.get_mapping(detector)
 
 
 """ setup the decoder """
-reader = decoder.decoder(detector, run, str(sub), dataflow+"-"+datawriter, hash_path, args.file)
+reader = decoder.decoder(detector, run, str(sub), dataflow+"-"+datawriter, hash_path, custom_file_path)#args.file)
 reader.open_file()
 nb_evt = reader.read_run_header()
 

--- a/settings/cbbot/path.json
+++ b/settings/cbbot/path.json
@@ -1,7 +1,8 @@
 {
     "cern":"/eos/experiment/neutplatform/protodune/rawdata/np04/vd-coldbox-bottom/raw/2023/detector/test/None",
     "cernnew":"/eos/experiment/neutplatform/protodune/dune/vd-coldbox/",
-    "fnal":"/pnfs/dune/tape_backed/dunepro/vd-coldbox-bottom/raw/2023/detector/test/None",
+    "fnal":"/pnfs/dune/tape_backed/dunepro/vd-coldbox/raw/2024/detector/cosmics/None/",
+    "fnal25":"/pnfs/dune/tape_backed/dunepro/vd-coldbox/raw/2025/detector/cosmics/None/",
     "custom":"/eos/user/l/lzambell/analysis/coldbox/CRP6"
 
 }

--- a/settings/pdhd/path.json
+++ b/settings/pdhd/path.json
@@ -1,5 +1,4 @@
 {
-    "mine":"/eos/user/l/lzambell/analysis/pdhd/runs",
     "cern":"/eos/experiment/neutplatform/protodune/dune/hd-protodune/",
-    "fnal":"/pnfs/dune/tape_backed/dunepro/vd-coldbox-top/raw/2022/detector/study/None"
+    "fnal":"/pnfs/dune/tape_backed/dunepro/hd-protodune/raw/2024/detector/cosmics/None/"
 }

--- a/settings/pdhd/reco_parameters.json
+++ b/settings/pdhd/reco_parameters.json
@@ -40,7 +40,8 @@
 	 
       "noise":{
           "coherent":{
-              "groupings":[32],
+              "per_view_per_card":0,
+	      "groupings":[32],
 	      "per_view":1,
 	      "capa_weight":0,
 	      "calibrated":0

--- a/settings/pdvd/path.json
+++ b/settings/pdvd/path.json
@@ -3,5 +3,5 @@
     "cern":"/eos/experiment/neutplatform/protodune/dune/vd-protodune/",
     "cern_top2":"/eos/experiment/neutplatform/protodune/dune/tdedata/",
     "cern_top":"/eos/experiment/neutplatform/protodune/rawdata/online_recon",
-    "fnal":"/pnfs/dune/tape_backed/dunepro/vd-coldbox-top/raw/2022/detector/study/None"
+    "fnal":"/pnfs/dune/tape_backed/dunepro/vd-protodune/raw/2025/detector/cosmics/None"
 }

--- a/store.py
+++ b/store.py
@@ -57,7 +57,7 @@ class NoiseStudy(IsDescription):
     delta_mean  = Float32Col(shape=(cf.n_tot_channels))
     rms         = Float32Col(shape=(cf.n_tot_channels))
 
-
+'''
 class FFT(IsDescription):
     """ ADJUST THE NUMBERS OF THE PS SHAPE ACCORDING TO THE RUN CONFIGURATION """
     print('test: ', (cf.module_nchan[0]/2, int(cf.n_sample[0]/2)+1), ' and ', cf.module_nchan[2]/2, int(cf.n_sample[2]/2)+1)
@@ -65,13 +65,14 @@ class FFT(IsDescription):
     ps_1 = Float32Col(shape=(cf.module_nchan[1], 3937))
     ps_2 = Float32Col(shape=(cf.module_nchan[2], 4033))
     ps_3 = Float32Col(shape=(cf.module_nchan[3], 4033))
-
-
+'''
+'''
 class Corr(IsDescription):
     corr_0 = Float32Col(shape=(cf.module_nchan[0], cf.module_nchan[0]))
     corr_1 = Float32Col(shape=(cf.module_nchan[1], cf.module_nchan[1]))
     corr_2 = Float32Col(shape=(cf.module_nchan[2], cf.module_nchan[2]))
     corr_3 = Float32Col(shape=(cf.module_nchan[3], cf.module_nchan[3]))
+'''
 
 class Waveform(IsDescription):
     view        = UInt8Col()
@@ -512,6 +513,7 @@ def store_noisestudy(h5file):
     ped['rms']  = chmap.arange_in_glob_channels(list(itt.chain.from_iterable(x.ped_rms for x in dc.evt_list[-1].noise_study)))
     ped.append()
 
+'''
 def store_fft(h5file, ps):
     #print('fft shapes: ', ps[0].shape, " ", ps[1].shape, " ", ps[2].shape, " ", ps[3].shape)
     print("WARNING !!! FFT PS PLOTS TAKE A LOT OF SPACE !!!")
@@ -526,7 +528,8 @@ def store_fft(h5file, ps):
     if(ps[3].shape[1] == 4033):
         fft['ps_3']   = ps[3]
     fft.append()
-
+'''
+'''
 def store_corr(h5file, corr):
     #print('STORE corr ', len(corr))    
     print("WARNING !! CORRELATION PLOTS TAKE A LOT OF SPACE !!!")
@@ -536,7 +539,7 @@ def store_corr(h5file, corr):
     cnr['corr_2']   = corr[2]
     cnr['corr_3']   = corr[3]
     cnr.append()
-
+'''
 
 def store_hits(h5file):
     hit = h5file.root.hits.row

--- a/workflow.py
+++ b/workflow.py
@@ -247,8 +247,8 @@ def charge_reco(deb, is_online):
     print('-- Found ', len(dc.single_hits_list), ' Single Hits!')
 
 def charge_reco_whole(is_online):
-
-
+    if(dc.evt_list[-1].det == 'cbbot' or dc.evt_list[-1].det == '50l' ):        
+        return
     
     stitch.stitch3D_across_modules([0,1])
     stitch.stitch3D_across_modules([2,3])


### PR DESCRIPTION
Some updates for running lardon at FNAL and for reading files with XRootD:
* updated the fnal specific pathes for PDHD, PDVD, and coldbox
Actually, most of the files are on tape and not easily accessible. The workaround is to use XRootD to have access to these files
- Update lardenv environment to include xrootd library
- Get your Justin token 
- Do `export LD_PRELOAD=/your/conda/env/lib/libXrdPosixPreload.so`
- run lardon with the -file option, where you provide the full file path as given by rucio (not a taped one)